### PR TITLE
Add recipe for building static binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ $(HOME)/.dub/packages/dstats-1.0.5/dstats/libdstats.a \
 $(HOME)/.dub/packages/resusage-0.2.8/resusage/lib/libresusage.a \
 $(HOME)/.dub/packages/tinyendian-0.1.2/tinyendian/libtinyendian.a
 
+DLIBS       = $(LIBRARY_PATH)/libphobos2-ldc.a $(LIBRARY_PATH)/libdruntime-ldc.a
+DLIBS_DEBUG = $(LIBRARY_PATH)/libphobos2-ldc-debug.a $(LIBRARY_PATH)/libdruntime-ldc-debug.a
 DFLAGS = -wi -I./source $(DUB_INCLUDE)
 RPATH  =
 LIBS   = -L=-llapacke -L=-llapack -L=-lblas -L=-lgsl -L=-lgslcblas -L=-lm -L=-lopenblas -L=-lm -L=-lgslcblas
@@ -68,7 +70,12 @@ ifeq ($(ARRAYFIRE),1)
   LIBS        += -L=-lafcuda
 endif
 
-debug: DFLAGS += -O0 -g -d-debug $(RPATH) -link-debuglib $(BACKEND_FLAG) -unittest
+debug:   DFLAGS += -O0 -g -d-debug $(RPATH) -link-debuglib $(BACKEND_FLAG) -unittest
+
+static:  DFLAGS +=  -static -link-defaultlib-shared=false  -L-static-libgfortran -L=-lgfortran
+
+static:  LIBS   =   $(DLIBS) $(LIBRARY_PATH)/libgsl.a $(LIBRARY_PATH)/libz.a $(LIBRARY_PATH)/liblapack.a $(LIBRARY_PATH)/liblapacke.a $(LIBRARY_PATH)/libgslcblas.a $(LIBRARY_PATH)/libopenblas.a $(LIBRARY_PATH)/libm.a -L=-lpthread
+
 release: DFLAGS += -O -release $(RPATH)
 
 profile: DFLAGS += -fprofile-instr-generate=fast_lmm_d-profiler.out
@@ -104,11 +111,11 @@ ifeq ($(VALIDATE),1)
 endif
 
 
-default debug release profile getIR getBC gperf: $(OUT)
+default debug release profile getIR getBC gperf static: $(OUT)
 
 # ---- Compile step
 %.o: %.d
-	$(D_COMPILER) -lib $(DFLAGS) -c $< -od=$(dir $@) $(BACKEND_FLAG)
+	$(D_COMPILER) $(DFLAGS) -c $< -od=$(dir $@) $(BACKEND_FLAG)
 
 # ---- Link step
 $(OUT): build-setup $(OBJ)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ and a bunch of D libraries.
 Install
 
 ```sh
-sudo apt-get install libopenblas liblapacke libgsl2
+sudo apt-get install libopenblas liblapacke libgsl2 gfortran
 ```
 
 Install LDC


### PR DESCRIPTION
There are some warnings because socket library needs a dynamic version of glibc.
```
prasun@ubuntu:~/dev/faster_lmm_d$ make LIBRARY_PATH=/usr/lib/x86_64-linux-gnu static
mkdir -p build/
ldc2 -of=build/faster_lmm_d -wi -I./source -I~/.dub/packages/cblas-1.0.0/cblas/source/ -I~/.dub/packages/dstats-1.0.5/dstats/source/ -I~/.dub/packages/dyaml-0.6.5/dyaml/source/ -I~/.dub/packages/gsl-0.1.8/gsl/source/ -I~/.dub/packages/lapack-0.0.6/lapack/source -I~/.dub/packages/resusage-0.2.8/resusage/source/ -I~/.dub/packages/tinyendian-0.1.2/tinyendian/source -static -link-defaultlib-shared=false  -L-static-libgfortran -L=-lgfortran  source/faster_lmm_d/helpers.o source/faster_lmm_d/gemma_io.o source/faster_lmm_d/cuda.o source/faster_lmm_d/arrayfire.o source/faster_lmm_d/lm.o source/faster_lmm_d/tsvreader.o source/faster_lmm_d/mvlmm.o source/faster_lmm_d/gwas.o source/faster_lmm_d/memory.o source/faster_lmm_d/logistic.o source/faster_lmm_d/bslmm.o source/faster_lmm_d/output.o source/faster_lmm_d/gemma.o source/faster_lmm_d/brent.o source/faster_lmm_d/gemma_kinship.o source/faster_lmm_d/phenotype.o source/faster_lmm_d/optmatrix.o source/faster_lmm_d/vcm.o source/faster_lmm_d/bslmm_dap.o source/faster_lmm_d/gemma_lmm.o source/faster_lmm_d/prune.o source/faster_lmm_d/dmatrix.o source/faster_lmm_d/lmm2.o source/faster_lmm_d/logistic_reg.o source/faster_lmm_d/gemma_association.o source/faster_lmm_d/gemma_param.o source/faster_lmm_d/kinship.o source/faster_lmm_d/rqtlreader.o source/faster_lmm_d/app.o source/test/pheno_vector.o source/test/fit.o source/test/geno_matrix.o source/test/pheno_generator.o source/test/geno_generator.o source/test/covar_matrix.o source/test/kinship.o source/test/gemma_lmm.o /usr/lib/x86_64-linux-gnu/libphobos2-ldc.a /usr/lib/x86_64-linux-gnu/libdruntime-ldc.a /usr/lib/x86_64-linux-gnu/libgsl.a /usr/lib/x86_64-linux-gnu/libz.a /usr/lib/x86_64-linux-gnu/liblapack.a /usr/lib/x86_64-linux-gnu/liblapacke.a /usr/lib/x86_64-linux-gnu/libgslcblas.a /usr/lib/x86_64-linux-gnu/libopenblas.a /usr/lib/x86_64-linux-gnu/libm.a -L=-lpthread /home/prasun/.dub/packages/dstats-1.0.5/dstats/libdstats.a /home/prasun/.dub/packages/dyaml-0.6.5/dyaml/libdyaml.a /home/prasun/.dub/packages/dstats-1.0.5/dstats/libdstats.a /home/prasun/.dub/packages/resusage-0.2.8/resusage/lib/libresusage.a /home/prasun/.dub/packages/tinyendian-0.1.2/tinyendian/libtinyendian.a 
/usr/lib/x86_64-linux-gnu/libphobos2-ldc.a(curl.o): In function `_D3std3net4curl7CurlAPI7loadAPIFZPv':
(.text._D3std3net4curl7CurlAPI7loadAPIFZPv[_D3std3net4curl7CurlAPI7loadAPIFZPv]+0xd): warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/x86_64-linux-gnu/libphobos2-ldc.a(path.o): In function `_D3std4path11expandTildeFNbAyaZ18expandFromDatabaseFNbQBbZQBf':
(.text._D3std4path11expandTildeFNbAyaZ18expandFromDatabaseFNbQBbZQBf[_D3std4path11expandTildeFNbAyaZ18expandFromDatabaseFNbQBbZQBf]+0xf1): warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/x86_64-linux-gnu/libphobos2-ldc.a(socket.o): In function `_D3std6socket20_sharedStaticCtor125FZv':
(.text._D3std6socket20_sharedStaticCtor125FZv[_D3std6socket20_sharedStaticCtor125FZv]+0x14): warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/x86_64-linux-gnu/libphobos2-ldc.a(socket.o): In function `_D3std6socket12InternetHost__T7getHostVAyaa118_0a2020202020202020202020206175746f2078203d2068746f6e6c28706172616d293b0a2020202020202020202020206175746f206865203d20676574686f73746279616464722826782c20342c206361737428696e7429204164647265737346616d696c792e494e4554293b0a2020202020202020TkZQJwMFkZb':
(.text._D3std6socket12InternetHost__T7getHostVAyaa118_0a2020202020202020202020206175746f2078203d2068746f6e6c28706172616d293b0a2020202020202020202020206175746f206865203d20676574686f73746279616464722826782c20342c206361737428696e7429204164647265737346616d696c792e494e4554293b0a2020202020202020TkZQJwMFkZb[_D3std6socket12InternetHost__T7getHostVAyaa118_0a2020202020202020202020206175746f2078203d2068746f6e6c28706172616d293b0a2020202020202020202020206175746f206865203d20676574686f73746279616464722826782c20342c206361737428696e7429204164647265737346616d696c792e494e4554293b0a2020202020202020TkZQJwMFkZb]+0x37): warning: Using 'gethostbyaddr' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/x86_64-linux-gnu/libphobos2-ldc.a(socket.o): In function `_D3std6socket12InternetHost__T7getHostVAyaa75_0a202020202020202020202020202020206175746f206865203d20676574686f737462796e616d6528706172616d2e74656d7043537472696e672829293b0a202020202020202020202020TAxaZQGpMFQjZb':
(.text._D3std6socket12InternetHost__T7getHostVAyaa75_0a202020202020202020202020202020206175746f206865203d20676574686f737462796e616d6528706172616d2e74656d7043537472696e672829293b0a202020202020202020202020TAxaZQGpMFQjZb[_D3std6socket12InternetHost__T7getHostVAyaa75_0a202020202020202020202020202020206175746f206865203d20676574686f737462796e616d6528706172616d2e74656d7043537472696e672829293b0a202020202020202020202020TAxaZQGpMFQjZb]+0x43): warning: Using 'gethostbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/x86_64-linux-gnu/libphobos2-ldc.a(socket.o): In function `_D3std6socket8Protocol17getProtocolByTypeMFNbNeEQBuQBt12ProtocolTypeZb':
(.text._D3std6socket8Protocol17getProtocolByTypeMFNbNeEQBuQBt12ProtocolTypeZb[_D3std6socket8Protocol17getProtocolByTypeMFNbNeEQBuQBt12ProtocolTypeZb]+0x7): warning: Using 'getprotobynumber' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/x86_64-linux-gnu/libphobos2-ldc.a(socket.o): In function `_D3std6socket8Protocol17getProtocolByNameMFNbNexAaZb':
(.text._D3std6socket8Protocol17getProtocolByNameMFNbNexAaZb[_D3std6socket8Protocol17getProtocolByNameMFNbNexAaZb]+0x26): warning: Using 'getprotobyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/x86_64-linux-gnu/libphobos2-ldc.a(socket.o): In function `_D3std6socket7Service16getServiceByNameMFNbNexAaxQdZb':
(.text._D3std6socket7Service16getServiceByNameMFNbNexAaxQdZb[_D3std6socket7Service16getServiceByNameMFNbNexAaxQdZb]+0x5d): warning: Using 'getservbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/x86_64-linux-gnu/libphobos2-ldc.a(socket.o): In function `_D3std6socket7Service16getServiceByPortMFNbNetxAaZb':
(.text._D3std6socket7Service16getServiceByPortMFNbNetxAaZb[_D3std6socket7Service16getServiceByPortMFNbNetxAaZb]+0x2a): warning: Using 'getservbyport' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
prasun@ubuntu:~/dev/faster_lmm_d$ ldd build/faster_lmm_d 
	not a dynamic executable
```